### PR TITLE
changed != to !== in state

### DIFF
--- a/src/State/Applications.ts
+++ b/src/State/Applications.ts
@@ -25,7 +25,7 @@ export class Applications extends smoothly.StateBase<Applications, userwidgets.C
 			this.request = request || undefined
 			result = await request
 			this.request = undefined
-			if (this.#current != result)
+			if (this.#current !== result)
 				this.listenable.current = result
 		}
 		return result || false

--- a/src/State/Me/Invite.ts
+++ b/src/State/Me/Invite.ts
@@ -22,7 +22,7 @@ export class Invite extends smoothly.StateBase<Invite, userwidgets.ClientCollect
 		const result = await promise
 		if (promise == this.request)
 			this.request = undefined
-		if (this.#value != result)
+		if (this.#value !== result)
 			this.listenable.value = result
 		return result || false
 	}

--- a/src/State/Me/index.ts
+++ b/src/State/Me/index.ts
@@ -30,7 +30,7 @@ export class Me extends smoothly.StateBase<Me, userwidgets.ClientCollection> {
 	): Promise<Me["key"] | userwidgets.User.Unauthenticated> {
 		let result: Me["key"] | userwidgets.User.Unauthenticated
 		const attempted = await this.client.me.login(user, twoFactor)
-		if (userwidgets.User.Key.is(attempted) && this.#key != attempted) {
+		if (userwidgets.User.Key.is(attempted) && this.#key !== attempted) {
 			this.listenable.key = attempted
 			result = attempted
 		} else if (userwidgets.User.Unauthenticated.is(attempted))
@@ -48,7 +48,7 @@ export class Me extends smoothly.StateBase<Me, userwidgets.ClientCollection> {
 		const result = await this.client.me
 			.register(invite, credentials)
 			.then(response => (!userwidgets.User.Key.is(response) ? false : response))
-		if (result && this.#key != result) {
+		if (result && this.#key !== result) {
 			this.listenable.key = result
 			sessionStorage.setItem("token", result.token)
 		}
@@ -60,7 +60,7 @@ export class Me extends smoothly.StateBase<Me, userwidgets.ClientCollection> {
 			: await this.client.me
 					.join(invite)
 					.then(response => ("issuer" in response ? response : response.status == 410 ? this.#key : false))
-		if (result && this.#key != result) {
+		if (result && this.#key !== result) {
 			this.listenable.key = result
 			sessionStorage.setItem("token", result.token)
 		}

--- a/src/State/Organizations.ts
+++ b/src/State/Organizations.ts
@@ -19,7 +19,7 @@ export class Organizations extends smoothly.StateBase<Organizations, userwidgets
 	set value(value: Organizations["value"]) {
 		this.#value = value
 		if (!value) {
-			if (value != this.#current)
+			if (value !== this.#current)
 				this.listenable.current = value
 		} else if (!this.#current) {
 			const id = window.localStorage.getItem(this.storage.current)
@@ -29,7 +29,7 @@ export class Organizations extends smoothly.StateBase<Organizations, userwidgets
 			const id = this.#current.id
 			const index = value.findIndex(organization => organization.id == id)
 			const current = value.at(Math.max(index, 0))
-			if (current != this.#current)
+			if (current !== this.#current)
 				this.listenable.current = current
 		}
 	}
@@ -41,12 +41,12 @@ export class Organizations extends smoothly.StateBase<Organizations, userwidgets
 		this.#current = current
 		if (!current) {
 			window.localStorage.removeItem(this.storage.current)
-			if (current != this.#value)
+			if (current !== this.#value)
 				this.listenable.value = current
 		} else if (this.#value && !this.#value.includes(current)) {
 			window.localStorage.setItem(this.storage.current, current.id)
 			const index = this.#value.findIndex(organization => organization.id == current.id)
-			if (index != -1)
+			if (index !== -1)
 				this.listenable.value = [...this.#value.slice(0, index), current, ...this.#value.slice(index + 1)]
 			else
 				this.listenable.value = [...this.#value, current]
@@ -69,7 +69,7 @@ export class Organizations extends smoothly.StateBase<Organizations, userwidgets
 			this.request = request || undefined
 			result = await request
 			this.request = undefined
-			if (this.#value != result)
+			if (this.#value !== result)
 				this.listenable.value = result
 		}
 		return result || false

--- a/src/State/Roles/index.ts
+++ b/src/State/Roles/index.ts
@@ -14,7 +14,7 @@ export class Roles extends smoothly.StateBase<Roles> {
 	private set key(key: Me["key"]) {
 		this.#admin = !!(key && userwidgets.User.Permissions.check(key.permissions, "*", "user.edit"))
 		const roles = this.#admin ? this.#application : this.#organization
-		if (roles != this.#default)
+		if (roles !== this.#default)
 			this.listenable.default = roles
 	}
 	#translate: Role.Translate = {}
@@ -26,7 +26,7 @@ export class Roles extends smoothly.StateBase<Roles> {
 		const old = this.#translator.custom
 		this.#translator.custom = translator
 		this.#translate.custom = this.#language && this.#translator.custom?.(this.#language)
-		if (old != this.#translator.custom)
+		if (old !== this.#translator.custom)
 			this.listenable.value = this.#value
 	}
 	#language?: Roles["language"]
@@ -35,7 +35,7 @@ export class Roles extends smoothly.StateBase<Roles> {
 		this.#language = language
 		this.#translate.custom = this.#language && this.#translator.custom?.(this.#language)
 		this.#translate.default = this.#language && this.#translator.default?.(this.#language)
-		if (old != this.#language) {
+		if (old !== this.#language) {
 			this.listenable.default = this.#default
 			this.listenable.value = this.#value
 		}
@@ -46,7 +46,7 @@ export class Roles extends smoothly.StateBase<Roles> {
 		return this.#value ?? this.default
 	}
 	set value(roles: Roles["value"]) {
-		if (roles != this.#value)
+		if (roles !== this.#value)
 			this.#value = roles?.map(role => Role.translate(role, this.#translate))
 	}
 	#application?: Roles["default"]
@@ -56,7 +56,7 @@ export class Roles extends smoothly.StateBase<Roles> {
 		return this.#default
 	}
 	set default(roles: Roles["default"]) {
-		if (roles != this.#default)
+		if (roles !== this.#default)
 			this.#default = roles?.map(role => Role.translate(role, this.#translate))
 	}
 	private organization(permissions: string[]): void {

--- a/src/State/Users.ts
+++ b/src/State/Users.ts
@@ -47,7 +47,7 @@ export class Users extends smoothly.StateBase<Users, userwidgets.ClientCollectio
 			this.request = request || undefined
 			result = await request
 			this.request = undefined
-			if (this.#value != result)
+			if (this.#value !== result)
 				this.listenable.value = result
 		}
 		return result || false


### PR DESCRIPTION
There were cases in the state where the comparison `[] != false` could occur with [unexpected results](https://www.typescriptlang.org/play?#code/MYewdgziA2CmB0w4EMBOAKAlAKAGYFcxgAXAS3AAJcQR0AjNALiuWglgoB8Kx8BbOrFQBtALqYKAb2wBIUrgr00FAIQBeFm1gTpMmQHoAVBQaoKpMLiGwAJhWIge-QSNEAaCqFSpYJFYtJ7AAsLAGsJQ31ZGVBIGARoEABzJVQPACJ1e0dcVnZ0nBkAXwpYLSlooxNlCysfOwdNdg8AOQB5ABUKAGE2gCU+gFFujv9I6NioOHhElNMMtQ1G3K0C2SLsDepaFfYcbfQxfZpDgEZxIA). Updated all `!=` operations to `!==` to fix this issue. Changing all of them is not necessary but all of them were changed for consistency.