### PR TITLE
no longer logged out when refreshing

### DIFF
--- a/src/State/Me/index.ts
+++ b/src/State/Me/index.ts
@@ -79,7 +79,7 @@ export class Me extends smoothly.StateBase<Me, userwidgets.ClientCollection> {
 		const key = window.sessionStorage.getItem("token")
 		if (key)
 			userwidgets.User.Key.Verifier.create(client.configuration.publicKey)
-				.verify(key)
+				.unpack(key)
 				.then(key => (listenable.key = key || false))
 		return listenable
 	}


### PR DESCRIPTION
With updated authly verify fails if no algorithm was used. In this case we do not care about the legitimacy of the key so we use the new unpack. which accomplishes what was done before.